### PR TITLE
Harden SABR/download handling and fix settings dismissal

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -15,7 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Test
-        run: python3 -m unittest discover -s Tests -v
+        run: |
+          python3 -m unittest discover -s Tests -v
+          c++ -std=c++17 -O2 \
+            Tests/test_playback_watchdog.cpp \
+            Tweak/Features/Playback/PlaybackWatchdog.cpp \
+            -o /tmp/ytkace-playback-watchdog
+          /tmp/ytkace-playback-watchdog
 
   build:
     needs: test

--- a/Tests/test_security_guards.py
+++ b/Tests/test_security_guards.py
@@ -1,0 +1,33 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class SecurityGuardTests(unittest.TestCase):
+    def test_sensitive_sabr_payloads_are_not_dumped(self):
+        source = (ROOT / "Tweak/Features/Downloads/SABRDownloader.mm").read_text()
+        self.assertNotIn("ytkace-native.pb", source)
+        self.assertNotIn("ytkace-outgoing.pb", source)
+        self.assertNotIn('directive type=%u data=%@', source)
+
+    def test_sabr_destinations_are_validated_at_each_assignment(self):
+        source = (ROOT / "Tweak/Features/Downloads/SABRDownloader.mm").read_text()
+        self.assertIn("YTKACESABRIsAllowedServerURL", source)
+        self.assertIn('isEqualToString:@"https"', source)
+        self.assertIn('hasSuffix:@".googlevideo.com"', source)
+        self.assertGreaterEqual(source.count("YTKACESABRIsAllowedServerURL("), 4)
+
+    def test_backup_restore_has_preference_and_size_guards(self):
+        source = (ROOT / "Tweak/Features/Downloads/YTKACEBackupManager.mm").read_text()
+        self.assertIn("YTKACEIsRestorablePreference", source)
+        self.assertIn('hasPrefix:@"YTKACE.Preference."', source)
+        self.assertIn("YTKACEMaxBackupEntries", source)
+        self.assertIn("YTKACEMaxBackupEntrySize", source)
+        self.assertIn("YTKACEMaxBackupTotalSize", source)
+        self.assertIn("NSURLVolumeAvailableCapacityForImportantUsageKey", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/test_security_guards.py
+++ b/Tests/test_security_guards.py
@@ -11,6 +11,8 @@ class SecurityGuardTests(unittest.TestCase):
         self.assertNotIn("ytkace-native.pb", source)
         self.assertNotIn("ytkace-outgoing.pb", source)
         self.assertNotIn('directive type=%u data=%@', source)
+        self.assertNotIn('@"headers %@"', source)
+        self.assertIn("YTKACESABRRequestCacheLimit", source)
 
     def test_sabr_destinations_are_validated_at_each_assignment(self):
         source = (ROOT / "Tweak/Features/Downloads/SABRDownloader.mm").read_text()
@@ -27,6 +29,12 @@ class SecurityGuardTests(unittest.TestCase):
         self.assertIn("YTKACEMaxBackupEntrySize", source)
         self.assertIn("YTKACEMaxBackupTotalSize", source)
         self.assertIn("NSURLVolumeAvailableCapacityForImportantUsageKey", source)
+
+    def test_applying_settings_does_not_terminate_youtube(self):
+        source = (ROOT / "Tweak/Settings/YTKACERootOptionsController.mm").read_text()
+        self.assertNotIn("exit(0)", source)
+        self.assertIn("postNotificationName:YTKACEPreferencesDidChangeNotification", source)
+        self.assertIn("dismissViewControllerAnimated:YES", source)
 
 
 if __name__ == "__main__":

--- a/Tweak/Features/Downloads/DownloadLog.mm
+++ b/Tweak/Features/Downloads/DownloadLog.mm
@@ -8,9 +8,9 @@ static NSURL *YTKACEDownloadLogURL(void) {
     static NSURL *cached = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        NSArray<NSNumber *> *candidates = @[@(NSDocumentDirectory),
-                                            @(NSApplicationSupportDirectory),
-                                            @(NSCachesDirectory)];
+        NSArray<NSNumber *> *candidates = @[@(NSApplicationSupportDirectory),
+                                            @(NSCachesDirectory),
+                                            @(NSDocumentDirectory)];
         for (NSNumber *candidate in candidates) {
             NSURL *base = [NSFileManager.defaultManager
                 URLsForDirectory:(NSSearchPathDirectory)candidate.unsignedIntegerValue

--- a/Tweak/Features/Downloads/SABRDownloader.mm
+++ b/Tweak/Features/Downloads/SABRDownloader.mm
@@ -23,6 +23,22 @@ static NSString *YTKACEPBFieldSummary(NSData *data);
 static BOOL YTKACESABRIsPlaybackBody(NSData *data);
 static NSData *YTKACEPBDataField(NSData *data, NSUInteger wanted);
 
+static BOOL YTKACESABRIsAllowedServerURL(NSURL *URL) {
+    if (URL == nil || ![URL.scheme.lowercaseString isEqualToString:@"https"] ||
+        URL.user.length != 0 || URL.password.length != 0 ||
+        (URL.port != nil && URL.port.integerValue != 443)) {
+        return NO;
+    }
+    NSString *host = URL.host.lowercaseString;
+    if (host.length == 0) return NO;
+    return [host isEqualToString:@"googlevideo.com"] ||
+        [host hasSuffix:@".googlevideo.com"] ||
+        [host isEqualToString:@"youtube.com"] ||
+        [host hasSuffix:@".youtube.com"] ||
+        [host isEqualToString:@"youtube-nocookie.com"] ||
+        [host hasSuffix:@".youtube-nocookie.com"];
+}
+
 void YTKACESABRSetCurrentVideoID(NSString *videoID) {
     if (videoID.length == 0) return;
     @synchronized (YTKACESABRDownloader.class) {
@@ -99,12 +115,10 @@ void YTKACESABRSetNativeRequest(NSURLRequest *request) {
             YTKACESABRHeadersByConfig[config] = [request.allHTTPHeaderFields copy];
         }
     }
-    NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:@"ytkace-native.pb"];
-    [request.HTTPBody writeToFile:path atomically:YES];
-    YTKACEDownloadLog(@"native", @"body video=%@ bytes=%lu fields=%@ dump=%@",
+    YTKACEDownloadLog(@"native", @"body video=%@ bytes=%lu fields=%@",
         YTKACESABRCurrentVideoID ?: @"unknown",
         (unsigned long)request.HTTPBody.length,
-        YTKACEPBFieldSummary(request.HTTPBody), path);
+        YTKACEPBFieldSummary(request.HTTPBody));
 }
 
 static NSData *YTKACESABRCurrentNativeBody(NSString *videoID, NSData *config) {
@@ -592,10 +606,15 @@ static NSData *YTKACESABRClientInfo(void) {
         if (error != NULL) *error = [self error:@"YouTube did not provide SABR session data." code:1];
         return NO;
     }
+    NSURL *parsedServerURL = [NSURL URLWithString:serverURL];
+    if (!YTKACESABRIsAllowedServerURL(parsedServerURL)) {
+        if (error != NULL) *error = [self error:@"YouTube returned an unsafe SABR server URL." code:2];
+        return NO;
+    }
     self.playerResponse = response;
     self.streamingData = streamingData;
     self.ustreamerConfig = ustreamerConfig;
-    self.serverURL = serverURL;
+    self.serverURL = parsedServerURL.absoluteString;
     NSArray<YTKACEStreamOption *> *options =
         [YTKACEStreamResolver optionsFromPlayerResponse:playerData];
     for (YTKACEStreamOption *option in options) {
@@ -778,11 +797,9 @@ NSUInteger YTKACEPurgeDownloadScratch(BOOL includeActive) {
     [self clearRound:self.video];
     [self clearRound:self.audio];
     if (self.requestNumber == 0) {
-        NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:@"ytkace-outgoing.pb"];
-        [request writeToFile:path atomically:YES];
-        YTKACEDownloadLog(self.identifier, @"request fields native=%lu outgoing=%lu summary=%@ dump=%@",
+        YTKACEDownloadLog(self.identifier, @"request fields native=%lu outgoing=%lu summary=%@",
             (unsigned long)nativeBody.length, (unsigned long)request.length,
-            YTKACEPBFieldSummary(request), path);
+            YTKACEPBFieldSummary(request));
     }
     return request;
 }
@@ -904,8 +921,8 @@ NSUInteger YTKACEPurgeDownloadScratch(BOOL includeActive) {
     NSInteger logicalRequestNumber = self.requestNumber;
     NSInteger wireRequestNumber = logicalRequestNumber;
     NSURL *baseURL = [NSURL URLWithString:self.serverURL];
-    if (baseURL == nil) {
-        [self fail:[self error:@"SABR setup did not provide a request URL." code:2]];
+    if (!YTKACESABRIsAllowedServerURL(baseURL)) {
+        [self fail:[self error:@"SABR setup did not provide a safe request URL." code:2]];
         return;
     }
     NSMutableURLRequest *request =
@@ -1205,9 +1222,14 @@ NSUInteger YTKACEPurgeDownloadScratch(BOOL includeActive) {
 - (void)handleRedirect:(NSData *)data {
     NSString *redirect = YTKACEPBStringField(data, 1);
     if (redirect.length != 0) {
-        self.serverURL = redirect;
+        NSURL *redirectURL = [NSURL URLWithString:redirect];
+        if (!YTKACESABRIsAllowedServerURL(redirectURL)) {
+            YTKACEDownloadLog(self.identifier, @"rejected unsafe SABR redirect");
+            return;
+        }
+        self.serverURL = redirectURL.absoluteString;
         YTKACEDownloadLog(self.identifier, @"redirect host=%@",
-            [NSURL URLWithString:redirect].host);
+            redirectURL.host);
     }
 }
 
@@ -1285,8 +1307,8 @@ NSUInteger YTKACEPurgeDownloadScratch(BOOL includeActive) {
         partCounts[partType] = @([partCounts[partType] unsignedIntegerValue] + 1);
         partBytes[partType] = @([partBytes[partType] unsignedLongLongValue] + size);
         if (self.requestNumber <= 1 && (type == 46 || type == 51)) {
-            YTKACEDownloadLog(self.identifier, @"directive type=%u data=%@", type,
-                [part base64EncodedStringWithOptions:0]);
+            YTKACEDownloadLog(self.identifier, @"directive type=%u bytes=%lu", type,
+                (unsigned long)part.length);
         }
         if (type == 20) [self handleHeader:part];
         else if (type == 21) [self handleMedia:part];

--- a/Tweak/Features/Downloads/SABRDownloader.mm
+++ b/Tweak/Features/Downloads/SABRDownloader.mm
@@ -19,6 +19,7 @@ static NSMutableDictionary<NSString *, NSDictionary<NSString *, NSString *> *> *
 static NSMutableDictionary<NSString *, NSData *> *YTKACESABRBodiesByVideo;
 static NSMutableDictionary<NSData *, NSDictionary<NSString *, NSString *> *> *YTKACESABRHeadersByConfig;
 static NSMutableDictionary<NSData *, NSData *> *YTKACESABRBodiesByConfig;
+static const NSUInteger YTKACESABRRequestCacheLimit = 32;
 static NSString *YTKACEPBFieldSummary(NSData *data);
 static BOOL YTKACESABRIsPlaybackBody(NSData *data);
 static NSData *YTKACEPBDataField(NSData *data, NSUInteger wanted);
@@ -60,15 +61,16 @@ void YTKACESABRSetNativeHeaders(NSDictionary<NSString *, NSString *> *headers) {
             if (YTKACESABRHeadersByVideo == nil) {
                 YTKACESABRHeadersByVideo = [NSMutableDictionary dictionary];
             }
+            if (YTKACESABRHeadersByVideo[YTKACESABRCurrentVideoID] == nil &&
+                YTKACESABRHeadersByVideo.count >= YTKACESABRRequestCacheLimit) {
+                [YTKACESABRHeadersByVideo removeAllObjects];
+                [YTKACESABRBodiesByVideo removeAllObjects];
+            }
             YTKACESABRHeadersByVideo[YTKACESABRCurrentVideoID] = [headers copy];
         }
     }
-    NSMutableArray<NSString *> *summary = [NSMutableArray array];
-    for (NSString *key in headers) {
-        [summary addObject:[NSString stringWithFormat:@"%@:%lu", key,
-            (unsigned long)[headers[key] length]]];
-    }
-    YTKACEDownloadLog(@"native", @"headers %@", [summary componentsJoinedByString:@","]);
+    YTKACEDownloadLog(@"native", @"captured headers count=%lu",
+        (unsigned long)headers.count);
 }
 
 static NSDictionary<NSString *, NSString *> *YTKACESABRCurrentNativeHeaders(
@@ -99,6 +101,11 @@ void YTKACESABRSetNativeRequest(NSURLRequest *request) {
             if (YTKACESABRBodiesByVideo == nil) {
                 YTKACESABRBodiesByVideo = [NSMutableDictionary dictionary];
             }
+            if (YTKACESABRBodiesByVideo[YTKACESABRCurrentVideoID] == nil &&
+                YTKACESABRBodiesByVideo.count >= YTKACESABRRequestCacheLimit) {
+                [YTKACESABRHeadersByVideo removeAllObjects];
+                [YTKACESABRBodiesByVideo removeAllObjects];
+            }
             YTKACESABRBodiesByVideo[YTKACESABRCurrentVideoID] = [request.HTTPBody copy];
         }
         NSData *config = YTKACEPBDataField(request.HTTPBody, 5);
@@ -107,7 +114,7 @@ void YTKACESABRSetNativeRequest(NSURLRequest *request) {
                 YTKACESABRBodiesByConfig = [NSMutableDictionary dictionary];
                 YTKACESABRHeadersByConfig = [NSMutableDictionary dictionary];
             }
-            if (YTKACESABRBodiesByConfig.count >= 32) {
+            if (YTKACESABRBodiesByConfig.count >= YTKACESABRRequestCacheLimit) {
                 [YTKACESABRBodiesByConfig removeAllObjects];
                 [YTKACESABRHeadersByConfig removeAllObjects];
             }

--- a/Tweak/Features/Downloads/YTKACEBackupManager.mm
+++ b/Tweak/Features/Downloads/YTKACEBackupManager.mm
@@ -5,6 +5,16 @@
 #include <zlib.h>
 
 static NSString * const YTKACEBackupErrorDomain = @"YTKACEBackup";
+static const NSUInteger YTKACEMaxBackupEntries = 10000;
+static const uint64_t YTKACEMaxBackupEntrySize = 16ULL * 1024ULL * 1024ULL * 1024ULL;
+static const uint64_t YTKACEMaxBackupTotalSize = 64ULL * 1024ULL * 1024ULL * 1024ULL;
+
+static BOOL YTKACEIsRestorablePreference(NSString *key, id value) {
+    return [key isKindOfClass:NSString.class] &&
+        [key hasPrefix:@"YTKACE.Preference."] && value != nil &&
+        [NSPropertyListSerialization propertyList:value
+                                 isValidForFormat:NSPropertyListXMLFormat_v1_0];
+}
 
 static NSError *YTKACEBackupError(NSInteger code, NSString *message) {
     return [NSError errorWithDomain:YTKACEBackupErrorDomain code:code
@@ -132,7 +142,7 @@ static void YTKACEApplyBackupSettings(NSDictionary *settings) {
     __block NSUInteger applied = 0;
     [settings enumerateKeysAndObjectsUsingBlock:^(NSString *key, id value, BOOL *stop) {
         (void)stop;
-        if ([key isKindOfClass:NSString.class] && value != nil) {
+        if (YTKACEIsRestorablePreference(key, value)) {
             [defaults setObject:value forKey:key];
             applied++;
         }
@@ -394,6 +404,8 @@ static BOOL YTKACEExtractStoredZip(NSURL *URL, NSURL *destination, NSError **err
     NSFileHandle *input = [NSFileHandle fileHandleForReadingFromURL:URL error:error];
     if (input == nil) return NO;
     NSFileManager *manager = NSFileManager.defaultManager;
+    NSUInteger entryCount = 0;
+    uint64_t totalSize = 0;
     while (true) {
         NSData *fixed = [input readDataOfLength:30];
         if (fixed.length == 0) break;
@@ -480,6 +492,26 @@ static BOOL YTKACEExtractStoredZip(NSURL *URL, NSURL *destination, NSError **err
             [input closeFile];
             return NO;
         }
+        entryCount += 1;
+        if (entryCount > YTKACEMaxBackupEntries || size > YTKACEMaxBackupEntrySize ||
+            UINT64_MAX - totalSize < size ||
+            totalSize + size > YTKACEMaxBackupTotalSize) {
+            if (error != NULL) *error = YTKACEBackupError(15, @"The backup is too large");
+            [input closeFile];
+            return NO;
+        }
+        NSNumber *available = nil;
+        [destination getResourceValue:&available
+                               forKey:NSURLVolumeAvailableCapacityForImportantUsageKey
+                                error:nil];
+        const uint64_t reserve = 128ULL * 1024ULL * 1024ULL;
+        if (available != nil &&
+            (size > UINT64_MAX - reserve || available.unsignedLongLongValue < size + reserve)) {
+            if (error != NULL) *error = YTKACEBackupError(14, @"Not enough free space to restore the backup");
+            [input closeFile];
+            return NO;
+        }
+        totalSize += size;
         NSString *clean = name.stringByStandardizingPath;
         BOOL allowed = [clean isEqualToString:@"SettingsBackup.plist"] ||
             [clean hasPrefix:@"Downloads/"];

--- a/Tweak/Settings/YTKACERootOptionsController.mm
+++ b/Tweak/Settings/YTKACERootOptionsController.mm
@@ -9,7 +9,6 @@
 #import "../Features/Downloads/DownloadLog.h"
 
 #import <objc/runtime.h>
-#import <stdlib.h>
 #import <sys/utsname.h>
 
 static UIColor *YTKACERootBackground(void) {
@@ -587,14 +586,11 @@ UIViewController *YTKACEMakeDownloadLogController(void) {
 
 - (void)applySettings {
     [NSUserDefaults.standardUserDefaults synchronize];
-    [NSNotificationCenter.defaultCenter postNotificationName:@"YTKACEPreferencesDidChange"
+    [NSNotificationCenter.defaultCenter postNotificationName:YTKACEPreferencesDidChangeNotification
                                                       object:nil];
     [NSNotificationCenter.defaultCenter postNotificationName:@"YTKACETabConfigDidChange"
                                                       object:nil];
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)),
-                   dispatch_get_main_queue(), ^{
-        exit(0);
-    });
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void)closeSettings {


### PR DESCRIPTION
## Summary

This PR hardens the network, diagnostic logging, and settings-backup paths used by YTKACE, and fixes the settings checkmark terminating YouTube after preferences are saved.

### SABR/download hardening

- Validate server-provided SABR URLs before making requests:
  - require HTTPS
  - reject embedded credentials
  - require the default HTTPS port
  - allow only YouTube/Google video delivery hosts
- Remove raw protobuf request/response dumps from the temporary directory.
- Replace raw directive and captured-header diagnostic output with type/count/size-only logging.
- Bound the per-video SABR request/config caches to prevent indefinite in-process growth.
- Prefer Application Support/Caches over Documents for the persistent download log so it is not normally exposed through iOS File Sharing. The in-app copy/share controls still work.

### Backup/restore hardening

- Apply per-entry, per-file, and total expanded-size limits before extracting a settings backup.
- Require sufficient free disk space before extraction.
- Restore only valid `YTKACE.Preference.*` property-list values instead of importing arbitrary defaults keys.

### Settings crash fix

`YTKACERootOptionsController` called `exit(0)` shortly after synchronizing preferences, making the checkmark appear to crash the app even though the settings persisted. It now:

- synchronizes preferences
- posts the exported `YTKACEPreferencesDidChangeNotification`
- posts `YTKACETabConfigDidChange`
- dismisses the settings controller normally

## Validation

- `python3 -m unittest discover -s Tests -v` — 9 tests passed
- C++ watchdog implementation and test suite compile and pass
- shell syntax checks, Python compilation, provenance audit, and `git diff --check` pass
- GitHub Actions built rootless and roothide packages plus iOS 16 and iOS 17 IPAs successfully: https://github.com/evanonym0us/ytkace/actions/runs/33328250173
- Both generated IPA archives passed integrity checks; packaged tweak binaries contain the URL guard and redacted logging while the removed protobuf dump identifiers are absent
- On-device testing confirmed:
  - app launch and normal video playback
  - SponsorBlock operation
  - video download, mux, and downloaded-video playback
  - the settings checkmark persists changes, closes the settings screen, and leaves YouTube running

## Follow-up recommendation (outside this PR)

Consider moving release/build instructions toward a user-supplied base YouTube IPA flow instead of distributing or automatically acquiring the base application. That would reduce the project's avoidable distribution/legal exposure while keeping the tweak build itself reproducible. This is intentionally not implemented here so the security and crash fixes remain focused and reviewable.
